### PR TITLE
Add completion provider with single example

### DIFF
--- a/completions.json
+++ b/completions.json
@@ -1,0 +1,8 @@
+{
+    "completions": [
+        {
+            "label": ".search-panel-header > label",
+            "snippet": ".search-panel-header > label {\n\tmargin-top: 2px;\n\tmargin-bottom: 1px;\n\topacity: .6;\n}"
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "categories": [
     "Other"
   ],
-  "activationEvents": [],
+  "activationEvents": [
+    "*"
+  ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "Other"
   ],
   "activationEvents": [
-    "*"
+    "onLanguage:css"
   ],
   "main": "./out/extension.js",
   "contributes": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
+import json from '../completions.json';
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
@@ -21,8 +22,17 @@ export function activate(context: vscode.ExtensionContext) {
 
 	const completion = vscode.languages.registerCompletionItemProvider({ pattern: '**/userChrome.css' }, {
 		provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext) {
-			return [
-			];
+
+			let completions: vscode.CompletionItem[] = [];
+
+			for (let element of json.completions) {
+				const completion = new vscode.CompletionItem({ label: element.label!, description: "Firefox CSS" }, vscode.CompletionItemKind.Snippet);
+				completion.documentation = new vscode.MarkdownString(`\`\`\`css\n${element.snippet!}`);
+				completion.insertText = new vscode.SnippetString(element.snippet!);
+				completions.push(completion);
+			};
+
+			return completions;
 		}
 	});
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,8 +19,15 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.window.showInformationMessage('Hello World from firefox-css!');
 	});
 
-	context.subscriptions.push(disposable);
+	const completion = vscode.languages.registerCompletionItemProvider({ pattern: '**/userChrome.css' }, {
+		provideCompletionItems(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken, context: vscode.CompletionContext) {
+			return [
+			];
+		}
+	});
+
+	context.subscriptions.push(disposable, completion);
 }
 
 // This method is called when your extension is deactivated
-export function deactivate() {}
+export function deactivate() { }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,9 @@
 		],
 		"sourceMap": true,
 		"rootDir": "src",
-		"strict": true   /* enable all strict type-checking options */
+		"strict": true /* enable all strict type-checking options */,
+		"resolveJsonModule": true,
+		"esModuleInterop": true,
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */


### PR DESCRIPTION
Snippets only allow language (or project) restriction. We want to specifically target `userChrome.css` so not to pollute Intellisense with hundreds of suggestions for all CSS files. Thus, we need to programatically add snippets with "completions".

### Added
* Completions with single example
* Enablement of extension on language of CSS

Tracked against: None