### PR TITLE
Add command to launch Firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "contributes": {
     "commands": [
       {
-        "command": "firefox-css.helloWorld",
-        "title": "Hello World"
+        "command": "firefox-css.launch",
+        "title": "Launch Firefox"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,11 @@
             "All"
           ],
           "default": "All",
-          "description": "Used to show/hide platform-specific snippets."
+          "markdownDescription": "Specifies whether to show/hide platform-specific snippets."
+        },
+        "firefox.launch.path": {
+          "type": "string",
+          "markdownDescription": "Specifies the filepath of `firefox.exe`."
         }
       }
     }

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -33,9 +33,9 @@ suite('Extension Test Suite', () => {
     });
 
     [
-        { platform: "linux", descriptionPrefix: "Linux-specific Firefox CSS" },
-        { platform: "osx", descriptionPrefix: "macOS-specific Firefox CSS" },
-        { platform: "windows", descriptionPrefix: "Windows-specific Firefox CSS" },
+        { platform: "linux", descriptionPrefix: "Linux-specific Firefox CSS\n" },
+        { platform: "osx", descriptionPrefix: "macOS-specific Firefox CSS\n" },
+        { platform: "windows", descriptionPrefix: "Windows-specific Firefox CSS\n" },
         { platform: "non-platform", descriptionPrefix: "" },
     ].forEach(function (item) {
         test("getDesriptionPrefix return for '" + item.platform + "'", () => {

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -27,7 +27,7 @@ suite('Extension Test Suite', () => {
         { platform: "shared", targetPlatform: "non-platform", allowed: true },
         { platform: "", targetPlatform: "", allowed: true }, // Default
     ].forEach(function (item) {
-        test("isPlatformAllowedByConfiguration return for platform'" + item.platform + " with target platform '" + item.targetPlatform + "'", () => {
+        test("isPlatformAllowedByConfiguration return " + item.allowed + " for platform '" + item.platform + " with target platform '" + item.targetPlatform + "'", () => {
             assert.equal(item.allowed, myExtension.isPlatformAllowedByConfiguration(item.platform, item.targetPlatform));
         });
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,17 +12,22 @@ export function isPlatformAllowedByConfiguration(platform: string, targetPlatfor
 			if (!["All", "Linux"].includes(targetPlatform!)) {
 				return false;
 			}
+			break;
 		case "osx":
 			if (!["All", "macOS"].includes(targetPlatform!)) {
 				return false;
 			}
+			break;
 		case "windows":
 			if (!["All", "Windows"].includes(targetPlatform!)) {
 				return false;
 			}
+			break;
 		default:
-			return true;
+			break;
 	}
+
+	return true;
 }
 
 export function getDesriptionPrefix(platform: string): string {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,6 +44,7 @@ export function getDesriptionPrefix(platform: string): string {
 	}
 }
 
+/* istanbul ignore next: Platform dependant */
 export function getFirefoxExectuableLocation(): string | null {
 	const path = vscode.workspace.getConfiguration('firefoxCSS').get<string>('launch.path');
 	if (path && fs.existsSync(path)) {
@@ -56,7 +57,7 @@ export function getFirefoxExectuableLocation(): string | null {
 		case "darwin": // macOS
 		case "freebsd":
 		case "linux":
-		case "openbsd":
+		case "openbsd": 
 		case "sunos":
 			return null;
 		case "win32": // Windows

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,8 @@
 import * as vscode from 'vscode';
 import json from '../completions.json';
+import { exec } from 'node:child_process';
+
+let output = vscode.window.createOutputChannel("Firefox CSS");
 
 export function isPlatformAllowedByConfiguration(platform: string, targetPlatform_: string = ""): boolean {
 	const targetPlatform = targetPlatform_ ? targetPlatform_ : vscode.workspace.getConfiguration('firefoxCSS').get<string>('targetPlatform');
@@ -35,6 +38,10 @@ export function getDesriptionPrefix(platform: string): string {
 	}
 }
 
+export function getFirefoxExectuable(): string {
+	return `${process.env.PROGRAMFILES}\\Mozilla Firefox\\firefox.exe`;
+}
+
 /* istanbul ignore next: Difficult to unit test */
 export function activate(context: vscode.ExtensionContext) {
 
@@ -63,7 +70,17 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 
 	const launch = vscode.commands.registerCommand('firefox-css.launch', () => {
-		vscode.window.showInformationMessage('Launch Firefox!');
+		const result = exec(`"${getFirefoxExectuable()}"`, (error, _, stderr) => {
+			if (error) {
+				output.appendLine(`Launching Firefox failed with err: ${error.message}`);
+				return;
+			}
+
+			if (stderr) {
+				output.appendLine(`Launching Firefox failed with stderr: ${stderr}`);
+				return;
+			}
+		});
 	});
 
 	context.subscriptions.push(completion, launch);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,7 +62,11 @@ export function activate(context: vscode.ExtensionContext) {
 		}
 	});
 
-	context.subscriptions.push(completion);
+	const launch = vscode.commands.registerCommand('firefox-css.launch', () => {
+		vscode.window.showInformationMessage('Launch Firefox!');
+	});
+
+	context.subscriptions.push(completion, launch);
 }
 
 /* istanbul ignore next: Empty function */

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import json from '../completions.json';
-import { exec } from 'node:child_process';
+import { spawn } from 'node:child_process';
 
 let output = vscode.window.createOutputChannel("Firefox CSS");
 
@@ -85,16 +85,11 @@ export function activate(context: vscode.ExtensionContext) {
 	const launch = vscode.commands.registerCommand('firefox-css.launch', () => {
 		const firefoxExecutableLocation = getFirefoxExectuableLocation();
 		if (firefoxExecutableLocation) {
-			const result = exec(`"${firefoxExecutableLocation}"`, (error, _, stderr) => {
-				if (error) {
-					output.appendLine(`Launching Firefox failed with err: ${error.message}`);
-					return;
-				}
+			const firefoxProcess = spawn(`${firefoxExecutableLocation}`);
 
-				if (stderr) {
-					output.appendLine(`Launching Firefox failed with stderr: ${stderr}`);
-					return;
-				}
+			firefoxProcess.stderr.on("data", (data) => {
+				output.appendLine(`Launching Firefox failed with stderr: ${data}`);
+				return;
 			});
 		} else {
 			vscode.window.showWarningMessage("Could not find Firefox executable location.")

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import json from '../completions.json';
 import { spawn } from 'node:child_process';
+import fs from "fs";
 
 let output = vscode.window.createOutputChannel("Firefox CSS");
 
@@ -39,6 +40,11 @@ export function getDesriptionPrefix(platform: string): string {
 }
 
 export function getFirefoxExectuableLocation(): string | null {
+	const path = vscode.workspace.getConfiguration('firefoxCSS').get<string>('launch.path');
+	if (path && fs.existsSync(path)) {
+		return path;
+	}
+
 	switch (process.platform) {
 		case "aix":
 		case "android":


### PR DESCRIPTION
The user should be able to launch Firefox through a VSCode command.

### Added
* Command to launch Firefox
* Configuration to specify `firefox.exe` path

Tracked against: None