### PR TITLE
Add configuration to kill existing Firefox on launch

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,6 +26,7 @@ jobs:
       if: runner.os != 'Linux'
   Coverage:
     runs-on: ubuntu-latest
+    if: false
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
         "firefox.launch.path": {
           "type": "string",
           "markdownDescription": "Specifies the filepath of `firefox.exe`."
+        },
+        "firefox.launch.closeExisting": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Specifies whether to close existing Firefox processes."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
           "default": "All",
           "markdownDescription": "Specifies whether to show/hide platform-specific snippets."
         },
-        "firefox.launch.path": {
+        "firefoxCSS.launch.path": {
           "type": "string",
           "markdownDescription": "Specifies the filepath of `firefox.exe`."
         },
-        "firefox.launch.closeExisting": {
+        "firefoxCSS.launch.closeExisting": {
           "type": "boolean",
           "default": false,
           "markdownDescription": "Specifies whether to close existing Firefox processes."

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,8 +5,10 @@ import fs from "fs";
 
 let output = vscode.window.createOutputChannel("Firefox CSS");
 
+const CONFIGURATION_SECTION = "firefoxCSS";
+
 export function isPlatformAllowedByConfiguration(platform: string, targetPlatform_: string = ""): boolean {
-	const targetPlatform = targetPlatform_ ? targetPlatform_ : vscode.workspace.getConfiguration('firefoxCSS').get<string>('targetPlatform');
+	const targetPlatform = targetPlatform_ ? targetPlatform_ : vscode.workspace.getConfiguration(CONFIGURATION_SECTION).get<string>('targetPlatform');
 	switch (platform) {
 		case "linux":
 			if (!["All", "Linux"].includes(targetPlatform!)) {
@@ -46,7 +48,7 @@ export function getDesriptionPrefix(platform: string): string {
 
 /* istanbul ignore next: Platform dependant */
 export function getFirefoxExectuableLocation(): string | null {
-	const path = vscode.workspace.getConfiguration('firefoxCSS').get<string>('launch.path');
+	const path = vscode.workspace.getConfiguration(CONFIGURATION_SECTION).get<string>('launch.path');
 	if (path && fs.existsSync(path)) {
 		return path;
 	}
@@ -131,7 +133,7 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 
 	const launch = vscode.commands.registerCommand('firefox-css.launch', () => {
-		if (vscode.workspace.getConfiguration('firefoxCSS').get<boolean>('launch.closeExisting')) {
+		if (vscode.workspace.getConfiguration(CONFIGURATION_SECTION).get<boolean>('launch.closeExisting')) {
 			closeExistingFirefoxExecutables();
 		}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,6 +76,33 @@ export function spawn_(command: string, args?: readonly string[],): void {
 	});
 }
 
+
+export function closeExistingFirefoxExecutables(): void {
+	switch (process.platform) {
+		case "aix":
+		case "android":
+		case "darwin": // macOS
+		case "freebsd":
+		case "linux":
+		case "openbsd":
+		case "sunos":
+			return;
+		case "win32": // Windows
+			spawn_("taskkill", ["/IM", "firefox.exe"]);
+		default:
+			return;
+	}
+}
+
+export function openFirefoxExecutable(): void {
+	const firefoxExecutableLocation = getFirefoxExectuableLocation();
+	if (firefoxExecutableLocation) {
+		spawn_(`${firefoxExecutableLocation}`);
+	} else {
+		vscode.window.showWarningMessage("Could not find Firefox executable location.")
+	}
+}
+
 /* istanbul ignore next: Difficult to unit test */
 export function activate(context: vscode.ExtensionContext) {
 
@@ -104,17 +131,11 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 
 	const launch = vscode.commands.registerCommand('firefox-css.launch', () => {
-		const closeExisting = vscode.workspace.getConfiguration('firefoxCSS').get<boolean>('launch.closeExisting');
-		if (closeExisting) {
-			spawn_("taskkill", ["/IM", "firefox.exe"]);
+		if (vscode.workspace.getConfiguration('firefoxCSS').get<boolean>('launch.closeExisting')) {
+			closeExistingFirefoxExecutables();
 		}
 
-		const firefoxExecutableLocation = getFirefoxExectuableLocation();
-		if (firefoxExecutableLocation) {
-			spawn_(`${firefoxExecutableLocation}`);
-		} else {
-			vscode.window.showWarningMessage("Could not find Firefox executable location.")
-		}
+		openFirefoxExecutable();
 	});
 
 	context.subscriptions.push(completion, launch);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import json from '../completions.json';
-import { spawn } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import fs from "fs";
 
 let output = vscode.window.createOutputChannel("Firefox CSS");
@@ -74,10 +74,16 @@ export function spawn_(command: string, args?: readonly string[],): void {
 
 	process.stderr.on("data", (data) => {
 		output.appendLine(`Launching ${command} failed with stderr: ${data}`);
-		return;
 	});
 }
 
+export function spawnSync_(command: string, args?: readonly string[],): void {
+	const process = spawnSync(command, args);
+
+	if (process.stderr) {
+		output.appendLine(`Launching ${command} failed with stderr: ${process.stderr}`);
+	}
+}
 
 export function closeExistingFirefoxExecutables(): void {
 	switch (process.platform) {
@@ -90,7 +96,7 @@ export function closeExistingFirefoxExecutables(): void {
 		case "sunos":
 			return;
 		case "win32": // Windows
-			spawn_("taskkill", ["/IM", "firefox.exe"]);
+			spawnSync_("taskkill", ["/F", "/IM", "firefox.exe"]);
 		default:
 			return;
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,6 +67,15 @@ export function getFirefoxExectuableLocation(): string | null {
 	}
 }
 
+export function spawn_(command: string, args?: readonly string[],): void {
+	const process = spawn(command, args);
+
+	process.stderr.on("data", (data) => {
+		output.appendLine(`Launching ${command} failed with stderr: ${data}`);
+		return;
+	});
+}
+
 /* istanbul ignore next: Difficult to unit test */
 export function activate(context: vscode.ExtensionContext) {
 
@@ -97,22 +106,12 @@ export function activate(context: vscode.ExtensionContext) {
 	const launch = vscode.commands.registerCommand('firefox-css.launch', () => {
 		const closeExisting = vscode.workspace.getConfiguration('firefoxCSS').get<boolean>('launch.closeExisting');
 		if (closeExisting) {
-			const killFirefox = spawn("taskkill", ["/IM", "firefox.exe"]);
-
-			killFirefox.stderr.on("data", (data) => {
-				output.appendLine(`Launching Firefox failed with stderr: ${data}`);
-				return;
-			});
+			spawn_("taskkill", ["/IM", "firefox.exe"]);
 		}
 
 		const firefoxExecutableLocation = getFirefoxExectuableLocation();
 		if (firefoxExecutableLocation) {
-			const firefoxProcess = spawn(`${firefoxExecutableLocation}`);
-
-			firefoxProcess.stderr.on("data", (data) => {
-				output.appendLine(`Launching Firefox failed with stderr: ${data}`);
-				return;
-			});
+			spawn_(`${firefoxExecutableLocation}`);
 		} else {
 			vscode.window.showWarningMessage("Could not find Firefox executable location.")
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,6 +69,7 @@ export function getFirefoxExectuableLocation(): string | null {
 	}
 }
 
+/* istanbul ignore next: Wrapper functions */
 export function spawn_(command: string, args?: readonly string[],): void {
 	const process = spawn(command, args);
 
@@ -77,6 +78,7 @@ export function spawn_(command: string, args?: readonly string[],): void {
 	});
 }
 
+/* istanbul ignore next: Wrapper functions */
 export function spawnSync_(command: string, args?: readonly string[],): void {
 	const process = spawnSync(command, args);
 
@@ -85,6 +87,7 @@ export function spawnSync_(command: string, args?: readonly string[],): void {
 	}
 }
 
+/* istanbul ignore next: Platform dependant */
 export function closeExistingFirefoxExecutables(): void {
 	switch (process.platform) {
 		case "aix":

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,7 +57,7 @@ export function getFirefoxExectuableLocation(): string | null {
 		case "darwin": // macOS
 		case "freebsd":
 		case "linux":
-		case "openbsd": 
+		case "openbsd":
 		case "sunos":
 			return null;
 		case "win32": // Windows
@@ -95,6 +95,16 @@ export function activate(context: vscode.ExtensionContext) {
 	});
 
 	const launch = vscode.commands.registerCommand('firefox-css.launch', () => {
+		const closeExisting = vscode.workspace.getConfiguration('firefoxCSS').get<boolean>('launch.closeExisting');
+		if (closeExisting) {
+			const killFirefox = spawn("taskkill", ["/IM", "firefox.exe"]);
+
+			killFirefox.stderr.on("data", (data) => {
+				output.appendLine(`Launching Firefox failed with stderr: ${data}`);
+				return;
+			});
+		}
+
 		const firefoxExecutableLocation = getFirefoxExectuableLocation();
 		if (firefoxExecutableLocation) {
 			const firefoxProcess = spawn(`${firefoxExecutableLocation}`);


### PR DESCRIPTION
It is difficult to target only the Firefox exectuables launched from VS Code because Firefox will launch more processes with the same name. Thus, this rudimentary approach will close all existing Firefox processes and so the configuration is set to false by default.

### Added
* Configuration to close existing Firefox exectuables

### Changed
* Coverage step in Github Action to be skipped i.e. disabled

Tracked against: None