### PR TITLE
Update aggregate GitHub action to push to completions branch

### DIFF
--- a/.github/workflows/aggregate.yml
+++ b/.github/workflows/aggregate.yml
@@ -2,7 +2,7 @@ name: Aggregate
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0/30 * * * *"
 
 jobs:
   Aggregate:

--- a/.github/workflows/aggregate.yml
+++ b/.github/workflows/aggregate.yml
@@ -46,6 +46,7 @@ jobs:
     - name: Checkout firefox-css
       uses: actions/checkout@v4
       with:
+          ref: completions
           token: ${{ secrets.GITHUB_TOKEN }}
     - name: Download artifacts
       uses: actions/download-artifact@v4


### PR DESCRIPTION
The main branch is protected and needs a pull request for a change to be made. This cannot be bypassed by GitHub actions. An unhelpful solution from GitHub is to create a GitHub app which is overkill. For now, completions has no protections which is potentially a security hole.

### Changed
* Aggregate GitHub action to push to completions branch

Tracked against: None