### PR TITLE
Run aggregate GitHub action nightly

### DIFF
--- a/.github/workflows/aggregate.yml
+++ b/.github/workflows/aggregate.yml
@@ -2,7 +2,7 @@ name: Aggregate
 
 on:
   schedule:
-    - cron: "0/30 * * * *"
+    - cron: "0 0 * * *"
 
 jobs:
   Aggregate:


### PR DESCRIPTION
Pull request #21 was merged with the aggregate GitHub action to run every 30 minutes. This was temporary measure to test the GitHub action and can now be reverted.

### Added
_Use unordered list (bullet points) to reference updates otherwise remove heading if no updates to reference_

### Changed
* Cron of aggregate GitHub action

Tracked against: None