### PR TITLE
Enable coverage

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,7 +26,6 @@ jobs:
       if: runner.os != 'Linux'
   Coverage:
     runs-on: ubuntu-latest
-    if: false
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -6,7 +6,7 @@ export async function downloadCompletions(source: string): Promise<void> {
     try {
         const response = await fetch(url);
         const text = await response.text();
-        const json = JSON.parse(JSON.stringify(text));
+        const json = JSON.parse(text);
 
         output.appendLine(`Fetched completions (${text.length} bytes) from: ${url}`);
         completions = json;


### PR DESCRIPTION
This was noticed in development and was found by reverting the previous commit 464bf6a30ae3d26a145c2a75e95873277a9be055.

### Changed
* GitHub action to enable coverage

### Fixed
* Completions not being parsed

Tracked against: None