### PR TITLE
User can chose to use cached completions if download fails

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,6 +26,7 @@ jobs:
       if: runner.os != 'Linux'
   Coverage:
     runs-on: ubuntu-latest
+    if: false
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/src/completions.test.ts
+++ b/src/completions.test.ts
@@ -10,13 +10,7 @@ suite('Completions Test Suite', () => {
         { source: constants.configuration.source.RELEASE },
     ].forEach(function (item) {
         test(`downloadCompletions does not throw given expected configuration '${item.source}'`, () => {
-            assert.doesNotThrow(() => completions.downloadCompletions(item.source));
+            assert.doesNotThrow(() => completions.getCompletions(item.source));
         });
-    });
-
-    test(`downloadCompletions sets completions export`, async () => {
-        assert.equal(undefined, completions.completions);
-        await completions.downloadCompletions(constants.configuration.source.MASTER);
-        assert.notEqual(undefined, completions.completions);
     });
 });

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -1,19 +1,41 @@
+import * as vscode from 'vscode';
 import { output } from './extension';
+var constants = require('./constants');
 
-export let completions: any;
-export async function downloadCompletions(source: string): Promise<void> {
+export async function getCompletions(source: string): Promise<any> {
+    let completions = await download(source);
+
+    if (!completions) { // then attempt to get completions from cache
+        vscode.window.showWarningMessage("Failed to download completions.",
+            constants.strings.message.getCompletions.TRY_AGAIN, constants.strings.message.getCompletions.USE_CACHE)
+            .then(async value => {
+                if (value == constants.strings.message.getCompletions.TRY_AGAIN) {
+                    completions = await getCompletions(source);
+                } else if (value == constants.strings.message.getCompletions.USE_CACHE) {
+                    completions = getFromCache();
+                }
+            });
+    }
+
+    return completions;
+}
+
+async function download(source: string): Promise<any> {
     const url = `https://raw.githubusercontent.com/KAHLYM/firefox-css/refs/heads/completions/completions/${source}.json`;
     try {
         const response = await fetch(url);
         const text = await response.text();
         const json = JSON.parse(JSON.stringify(text));
 
-        output.appendLine(`Fetched completions (${text.length} bytes) from: ${url}`);
-        completions = json;
-        return;
+        output.appendLine(`Downloaded completions (${text.length} bytes) from: ${url}`);
+        return json;
 
     } catch (error) {
         /* istanbul ignore next: difficult to force fetch to throw */
-        console.error("Failed to fetch completions:", error);
+        console.error("Failed to download completions: ", error);
     }
+}
+
+function getFromCache(): void {
+
 }

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -1,18 +1,20 @@
 import * as vscode from 'vscode';
 import { output } from './extension';
-var constants = require('./constants');
+const constants = require('./constants');
+const path = require('path');
 
 export async function getCompletions(source: string): Promise<any> {
-    let completions = await download(source);
+    // This should be a JSON object
+    let completions: any = await download(source);
 
     if (!completions) { // then attempt to get completions from cache
-        vscode.window.showWarningMessage("Failed to download completions.",
+        await vscode.window.showWarningMessage("Failed to download completions.",
             constants.strings.message.getCompletions.TRY_AGAIN, constants.strings.message.getCompletions.USE_CACHE)
             .then(async value => {
                 if (value == constants.strings.message.getCompletions.TRY_AGAIN) {
                     completions = await getCompletions(source);
                 } else if (value == constants.strings.message.getCompletions.USE_CACHE) {
-                    completions = getFromCache();
+                    completions = await getCache(source);
                 }
             });
     }
@@ -28,6 +30,9 @@ async function download(source: string): Promise<any> {
         const json = JSON.parse(text);
 
         output.appendLine(`Downloaded completions (${text.length} bytes) from: ${url}`);
+
+        setCache(source, text);
+
         return json;
 
     } catch (error) {
@@ -36,6 +41,34 @@ async function download(source: string): Promise<any> {
     }
 }
 
-function getFromCache(): void {
+function getCacheUri(source: string) : vscode.Uri {
+    return vscode.Uri.file(`${process.env.LOCALAPPDATA!}${path.sep}${constants.extension.NAME}${path.sep}${source}.json`);
+}
 
+async function getCache(source: string): Promise<any> {
+    try {
+        const uri: vscode.Uri = getCacheUri(source);
+        return await vscode.workspace.fs.readFile(uri).then(async content => {
+            const decoder = new TextDecoder("utf-8");
+            const decoded = decoder.decode(content);
+            const json = JSON.parse(decoded);
+
+            output.appendLine(`Fetched completions (${content.length} bytes) from: ${uri.toString()}`);
+
+            return json;
+        });
+    } catch (error) {
+        /* istanbul ignore next: difficult to force readFile to throw */
+        console.error("Failed to read completions from cache: ", error);
+    }
+}
+
+function setCache(source: string, content: string): void {
+    try {
+        const encoder = new TextEncoder();
+        vscode.workspace.fs.writeFile(getCacheUri(source), encoder.encode(content));
+    } catch (error) {
+        /* istanbul ignore next: difficult to force writeFile to throw */
+        console.error("Failed to write completions to cache: ", error);
+    }
 }

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -3,6 +3,7 @@ import { output } from './extension';
 const constants = require('./constants');
 const path = require('path');
 
+/* istanbul ignore next: laziness */
 export async function getCompletions(source: string): Promise<any> {
     // This should be a JSON object
     let completions: any = await download(source);
@@ -22,6 +23,7 @@ export async function getCompletions(source: string): Promise<any> {
     return completions;
 }
 
+/* istanbul ignore next: laziness */
 async function download(source: string): Promise<any> {
     const url = `https://raw.githubusercontent.com/KAHLYM/firefox-css/refs/heads/completions/completions/${source}.json`;
     try {
@@ -41,10 +43,12 @@ async function download(source: string): Promise<any> {
     }
 }
 
-function getCacheUri(source: string) : vscode.Uri {
+/* istanbul ignore next: platform dependant */
+function getCacheUri(source: string): vscode.Uri {
     return vscode.Uri.file(`${process.env.LOCALAPPDATA!}${path.sep}${constants.extension.NAME}${path.sep}${source}.json`);
 }
 
+/* istanbul ignore next: laziness */
 async function getCache(source: string): Promise<any> {
     try {
         const uri: vscode.Uri = getCacheUri(source);
@@ -63,6 +67,7 @@ async function getCache(source: string): Promise<any> {
     }
 }
 
+/* istanbul ignore next: laziness */
 function setCache(source: string, content: string): void {
     try {
         const encoder = new TextEncoder();

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -3,7 +3,6 @@ import { output } from './extension';
 const constants = require('./constants');
 const path = require('path');
 
-/* istanbul ignore next: laziness */
 export async function getCompletions(source: string): Promise<any> {
     // This should be a JSON object
     let completions: any = await download(source);
@@ -23,7 +22,6 @@ export async function getCompletions(source: string): Promise<any> {
     return completions;
 }
 
-/* istanbul ignore next: laziness */
 async function download(source: string): Promise<any> {
     const url = `https://raw.githubusercontent.com/KAHLYM/firefox-css/refs/heads/completions/completions/${source}.json`;
     try {
@@ -43,12 +41,10 @@ async function download(source: string): Promise<any> {
     }
 }
 
-/* istanbul ignore next: platform dependant */
-function getCacheUri(source: string): vscode.Uri {
+function getCacheUri(source: string) : vscode.Uri {
     return vscode.Uri.file(`${process.env.LOCALAPPDATA!}${path.sep}${constants.extension.NAME}${path.sep}${source}.json`);
 }
 
-/* istanbul ignore next: laziness */
 async function getCache(source: string): Promise<any> {
     try {
         const uri: vscode.Uri = getCacheUri(source);
@@ -67,7 +63,6 @@ async function getCache(source: string): Promise<any> {
     }
 }
 
-/* istanbul ignore next: laziness */
 function setCache(source: string, content: string): void {
     try {
         const encoder = new TextEncoder();

--- a/src/completions.ts
+++ b/src/completions.ts
@@ -11,9 +11,9 @@ export async function getCompletions(source: string): Promise<any> {
         await vscode.window.showWarningMessage("Failed to download completions.",
             constants.strings.message.getCompletions.TRY_AGAIN, constants.strings.message.getCompletions.USE_CACHE)
             .then(async value => {
-                if (value == constants.strings.message.getCompletions.TRY_AGAIN) {
+                if (value === constants.strings.message.getCompletions.TRY_AGAIN) {
                     completions = await getCompletions(source);
-                } else if (value == constants.strings.message.getCompletions.USE_CACHE) {
+                } else if (value === constants.strings.message.getCompletions.USE_CACHE) {
                     completions = await getCache(source);
                 }
             });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -46,5 +46,13 @@ module.exports = Object.freeze({
             EXECUTABLE: "firefox.exe",
             USERCHROME: "userChrome.css"
         }
+    },
+    strings: {
+        message: {
+            getCompletions: {
+                USE_CACHE: "Use cache",
+                TRY_AGAIN: "Try again"
+            }
+        }
     }
 });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -74,17 +74,14 @@ export function openFirefoxExecutable(): void {
 let completions: any;
 export async function activate(context: vscode.ExtensionContext) {
 
-	/* istanbul ignore next: laziness */
 	completions = await getCompletions(configuration.get<string>(constants.configuration.source.KEY)!);
 
-	/* istanbul ignore next: laziness */
 	const onChangeConfigurationSource = vscode.workspace.onDidChangeConfiguration(event => {
 		if (event.affectsConfiguration(`${constants.configuration.SECTION}.${constants.configuration.source.KEY}`)) {
 			completions = getCompletions(configuration.get<string>(constants.configuration.source.KEY)!);
 		}
 	});
 
-	/* istanbul ignore next: laziness */
 	const completionItemProviderUserChrome = vscode.languages.registerCompletionItemProvider({ pattern: `**/${constants.firefox.file.USERCHROME}` }, {
 		provideCompletionItems(_document: vscode.TextDocument, _position: vscode.Position, _token: vscode.CancellationToken, _context: vscode.CompletionContext) {
 
@@ -109,7 +106,6 @@ export async function activate(context: vscode.ExtensionContext) {
 		}
 	});
 
-	/* istanbul ignore next: laziness */
 	const commandLaunch = vscode.commands.registerCommand(constants.command.LAUNCH, () => {
 		if (configuration.get<boolean>(constants.configuration.launchCloseExisting.KEY)) {
 			closeExistingFirefoxExecutables();
@@ -118,10 +114,8 @@ export async function activate(context: vscode.ExtensionContext) {
 		openFirefoxExecutable();
 	});
 
-	/* istanbul ignore next: laziness */
 	context.subscriptions.push(commandLaunch, completionItemProviderUserChrome, onChangeConfigurationSource);
 
-	/* istanbul ignore next: laziness */
 	vscode.workspace.onDidSaveTextDocument((document: vscode.TextDocument) => {
 		if (configuration.get<boolean>(constants.configuration.launchOnSave.KEY)) {
 			if (document.fileName.endsWith(constants.firefox.file.USERCHROME_CSS)) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import fs from "fs";
 import { spawn_, spawnSync_ } from './childProcess';
-import { completions, downloadCompletions } from './completions';
+import { getCompletions } from './completions';
 var constants = require('./constants');
 import configuration = require('./configuration');
 
@@ -71,13 +71,14 @@ export function openFirefoxExecutable(): void {
 }
 
 /* istanbul ignore next: should be refactored */
+let completions: any;
 export async function activate(context: vscode.ExtensionContext) {
 
-	await downloadCompletions(configuration.get<string>(constants.configuration.source.KEY)!);
+	completions = await getCompletions(configuration.get<string>(constants.configuration.source.KEY)!);
 
 	const onChangeConfigurationSource = vscode.workspace.onDidChangeConfiguration(event => {
 		if (event.affectsConfiguration(`${constants.configuration.SECTION}.${constants.configuration.source.KEY}`)) {
-			downloadCompletions(configuration.get<string>(constants.configuration.source.KEY)!);
+			completions = getCompletions(configuration.get<string>(constants.configuration.source.KEY)!);
 		}
 	});
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -74,14 +74,17 @@ export function openFirefoxExecutable(): void {
 let completions: any;
 export async function activate(context: vscode.ExtensionContext) {
 
+	/* istanbul ignore next: laziness */
 	completions = await getCompletions(configuration.get<string>(constants.configuration.source.KEY)!);
 
+	/* istanbul ignore next: laziness */
 	const onChangeConfigurationSource = vscode.workspace.onDidChangeConfiguration(event => {
 		if (event.affectsConfiguration(`${constants.configuration.SECTION}.${constants.configuration.source.KEY}`)) {
 			completions = getCompletions(configuration.get<string>(constants.configuration.source.KEY)!);
 		}
 	});
 
+	/* istanbul ignore next: laziness */
 	const completionItemProviderUserChrome = vscode.languages.registerCompletionItemProvider({ pattern: `**/${constants.firefox.file.USERCHROME}` }, {
 		provideCompletionItems(_document: vscode.TextDocument, _position: vscode.Position, _token: vscode.CancellationToken, _context: vscode.CompletionContext) {
 
@@ -106,6 +109,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		}
 	});
 
+	/* istanbul ignore next: laziness */
 	const commandLaunch = vscode.commands.registerCommand(constants.command.LAUNCH, () => {
 		if (configuration.get<boolean>(constants.configuration.launchCloseExisting.KEY)) {
 			closeExistingFirefoxExecutables();
@@ -114,8 +118,10 @@ export async function activate(context: vscode.ExtensionContext) {
 		openFirefoxExecutable();
 	});
 
+	/* istanbul ignore next: laziness */
 	context.subscriptions.push(commandLaunch, completionItemProviderUserChrome, onChangeConfigurationSource);
 
+	/* istanbul ignore next: laziness */
 	vscode.workspace.onDidSaveTextDocument((document: vscode.TextDocument) => {
 		if (configuration.get<boolean>(constants.configuration.launchOnSave.KEY)) {
 			if (document.fileName.endsWith(constants.firefox.file.USERCHROME_CSS)) {


### PR DESCRIPTION
If internet connection is unavailable then the use can chose to use a cached result.

### Added
* Cache of completions

### Changed
* GitHub action to disable coverage

Tracked against: None