### PR TITLE
Add command to open userChrome.css

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
       {
         "command": "firefox-css.launch",
         "title": "Launch Firefox"
+      },
+      {
+        "command": "firefox-css.open",
+        "title": "Open userChrome.css"
       }
     ],
     "configuration": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 module.exports = Object.freeze({
     command: {
         LAUNCH: "firefox-css.launch",
+        OPEN: "firefox-css.open",
     },
     configuration: {
         SECTION: "firefoxCSS",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -53,6 +53,10 @@ module.exports = Object.freeze({
             getCompletions: {
                 USE_CACHE: "Use cache",
                 TRY_AGAIN: "Try again"
+            },
+            open: {
+                CREATE: "Create",
+                DISMISS: "Dismiss"
             }
         }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,7 +54,7 @@ export function getFirefoxAppDataDirectory(): string | null {
 		case constants.platform.SUNOS:
 			return null;
 		case constants.platform.WIN32:
-			return `${process.env.APPDATA}\\Mozilla\\Firefox`;
+			return path.join(process.env.APPDATA, "Mozilla", "Firefox");
 		default:
 			return null;
 	}
@@ -172,10 +172,30 @@ export async function activate(context: vscode.ExtensionContext) {
 		vscode.window.showQuickPick(options, {
 			placeHolder: "Select Firefox profile"
 		}).then(pick => {
-		const filepath = vscode.Uri.file(path.join(getFirefoxAppDataDirectory(), "Profiles", pick?.label, "chrome", "userChrome.css"));
-			vscode.workspace.openTextDocument(filepath).then(document => {
-				vscode.window.showTextDocument(document);
-			});
+			const filepath = vscode.Uri.file(path.join(getFirefoxAppDataDirectory(), "Profiles", pick?.label, "chrome", "userChrome.css"));
+
+			if (!fs.existsSync(filepath.fsPath)) {
+				output.appendLine(`File does not exist: ${filepath.fsPath}`);
+				vscode.window.showWarningMessage("userChrome.css does not exists.",
+					constants.strings.message.open.CREATE, constants.strings.message.open.DISMISS)
+					.then(async value => {
+						if (value === constants.strings.message.open.CREATE) {
+							fs.mkdir(path.dirname(filepath.fsPath), { recursive: true }, _ => {
+								fs.writeFile(filepath.fsPath, "", _ => {
+									vscode.workspace.openTextDocument(filepath.fsPath).then(document => {
+										vscode.window.showTextDocument(document);
+									});
+								});
+							});
+						} else if (value === constants.strings.message.open.DISMISS) {
+							return;
+						}
+					});
+			} else {
+				vscode.workspace.openTextDocument(filepath).then(document => {
+					vscode.window.showTextDocument(document);
+				});
+			}
 		});
 	});
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,10 +1,10 @@
+import * as fs from "fs";
+import * as path from 'path';
 import * as vscode from 'vscode';
-import fs from "fs";
 import { spawn_, spawnSync_ } from './childProcess';
 import { getCompletions } from './completions';
-var constants = require('./constants');
-var path = require('path');
 import configuration = require('./configuration');
+let constants = require('./constants');
 
 export const output = vscode.window.createOutputChannel(constants.extension.NAME);
 
@@ -27,9 +27,9 @@ export function isPlatformAllowedByConfiguration(platform: string, targetPlatfor
 /* istanbul ignore next: platform-dependant */
 export function getFirefoxExectuableLocation(): string | null {
 	// Return user configuration if provided
-	const path = configuration.get<string>(constants.configuration.launchPath.KEY);
-	if (path && fs.existsSync(path)) {
-		return path;
+	const filepath = configuration.get<string>(constants.configuration.launchPath.KEY);
+	if (filepath && fs.existsSync(filepath)) {
+		return filepath;
 	}
 
 	// Otherwise, attempt to find Firefox exectuable 
@@ -40,7 +40,7 @@ export function getFirefoxExectuableLocation(): string | null {
 		case constants.platform.SUNOS:
 			return null;
 		case constants.platform.WIN32:
-			return `${process.env.PROGRAMFILES}\\Mozilla Firefox\\${constants.firefox.file.EXECUTABLE}`;
+			return path.join(process.env.PROGRAMFILES!, "Mozilla Firefox", constants.firefox.file.EXECUTABLE);
 		default:
 			return null;
 	}
@@ -54,7 +54,7 @@ export function getFirefoxAppDataDirectory(): string | null {
 		case constants.platform.SUNOS:
 			return null;
 		case constants.platform.WIN32:
-			return path.join(process.env.APPDATA, "Mozilla", "Firefox");
+			return path.join(process.env.APPDATA!, "Mozilla", "Firefox");
 		default:
 			return null;
 	}
@@ -151,7 +151,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	function getProfileDirectories(): ProfileDirectory[] {
 		let directories: ProfileDirectory[] = [];
-		const profiles = path.join(getFirefoxAppDataDirectory(), "Profiles");
+		const profiles = path.join(getFirefoxAppDataDirectory()!, "Profiles");
 		fs.readdirSync(profiles).forEach(file => {
 			directories.push(new ProfileDirectory(file, fs.statSync(path.join(profiles, file)).mtime));
 		});
@@ -170,7 +170,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		vscode.window.showQuickPick(options, {
 			placeHolder: "Select Firefox profile"
 		}).then(pick => {
-			const filepath = vscode.Uri.file(path.join(getFirefoxAppDataDirectory(), "Profiles", pick?.label, "chrome", constants.firefox.file.USERCHROME)).fsPath;
+			const filepath = vscode.Uri.file(path.join(getFirefoxAppDataDirectory()!, "Profiles", pick!.label, "chrome", constants.firefox.file.USERCHROME)).fsPath;
 
 			if (!fs.existsSync(filepath)) {
 				vscode.window.showWarningMessage("userChrome.css does not exists.",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -172,7 +172,7 @@ export async function activate(context: vscode.ExtensionContext) {
 		vscode.window.showQuickPick(options, {
 			placeHolder: "Select Firefox profile"
 		}).then(pick => {
-			const filepath = vscode.Uri.file(path.join(getFirefoxAppDataDirectory(), "Profiles", pick?.label, "chrome", "userChrome.css"));
+			const filepath = vscode.Uri.file(path.join(getFirefoxAppDataDirectory(), "Profiles", pick?.label, "chrome", constants.firefox.file.USERCHROME));
 
 			if (!fs.existsSync(filepath.fsPath)) {
 				output.appendLine(`File does not exist: ${filepath.fsPath}`);
@@ -180,12 +180,20 @@ export async function activate(context: vscode.ExtensionContext) {
 					constants.strings.message.open.CREATE, constants.strings.message.open.DISMISS)
 					.then(async value => {
 						if (value === constants.strings.message.open.CREATE) {
-							fs.mkdir(path.dirname(filepath.fsPath), { recursive: true }, _ => {
-								fs.writeFile(filepath.fsPath, "", _ => {
-									vscode.workspace.openTextDocument(filepath.fsPath).then(document => {
-										vscode.window.showTextDocument(document);
+							fs.mkdir(path.dirname(filepath.fsPath), { recursive: true }, (err) => {
+								if (err) {
+									output.appendLine(`Failed to create directories: ${err}`);
+								} else {
+									fs.writeFile(filepath.fsPath, "", (err) => {
+										if (err) {
+											output.appendLine(`Failed to write file: ${err}`);
+										} else {
+											vscode.workspace.openTextDocument(filepath.fsPath).then(document => {
+												vscode.window.showTextDocument(document);
+											});
+										};
 									});
-								});
+								};
 							});
 						} else if (value === constants.strings.message.open.DISMISS) {
 							return;


### PR DESCRIPTION
The command will open a QuickPick to select the appropriate profile.

### Added
* Command to open `userChrome.css` with option for user to create file if file does not exist

### Changed
* Imports to be ordered

Tracked against: None